### PR TITLE
fix: scope search paths to pod_target_xcconfig to fix precompiled RN builds

### DIFF
--- a/PiwikPROSDK.podspec
+++ b/PiwikPROSDK.podspec
@@ -51,12 +51,14 @@ Pod::Spec.new do |s|
 
   s.requires_arc = false
 
-  s.pod_target_xcconfig = { "HEADER_SEARCH_PATHS" => "$(PODS_ROOT)/**" }
+  s.pod_target_xcconfig = {
+    "HEADER_SEARCH_PATHS" => "$(PODS_ROOT)/**",
+    "FRAMEWORK_SEARCH_PATHS" => "$(PODS_ROOT)/",
+    "USER_HEADER_SEARCH_PATHS" => "$(PODS_ROOT)/**"
+  }
 
-  s.xcconfig     =  {
-  "FRAMEWORK_SEARCH_PATHS" => "$(PODS_ROOT)/", 
-  "USER_HEADER_SEARCH_PATHS" => "$(PODS_ROOT)/**", 
-  "OTHER_LDFLAGS" => "$(inherited) -ObjC"
+  s.xcconfig = {
+    "OTHER_LDFLAGS" => "$(inherited) -ObjC"
   }
 
 


### PR DESCRIPTION
## Summary

Move `FRAMEWORK_SEARCH_PATHS` and `USER_HEADER_SEARCH_PATHS` from `xcconfig` to `pod_target_xcconfig` in the podspec so these broad search paths no longer propagate to the consuming app target.

## Problem

`xcconfig` maps to `user_target_xcconfig` in CocoaPods, meaning `FRAMEWORK_SEARCH_PATHS = $(PODS_ROOT)/` is added to the **main app target's** build settings. With Expo SDK 54+ / React Native 0.81+, which ship precompiled React Native as `React-Core-prebuilt/React.xcframework`, this causes Clang to resolve the `React` module through the top-level xcframework `module.modulemap`, where the umbrella header can't be found:

```
umbrella header 'React_Core/React_Core-umbrella.h' not found
```

## Fix

Using `pod_target_xcconfig` keeps the search paths scoped to the PiwikPROSDK pod's own build, which is the [recommended CocoaPods practice](https://guides.cocoapods.org/syntax/podspec.html#user_target_xcconfig). Only `OTHER_LDFLAGS: -ObjC` remains in `xcconfig` since the consumer needs it for proper linking.

Fixes #22
Also related: PiwikPRO/react-native-piwik-pro-sdk#90
